### PR TITLE
HB-1828: Configurable opt out cookie

### DIFF
--- a/adapters/appnexus/appnexus_test.go
+++ b/adapters/appnexus/appnexus_test.go
@@ -328,7 +328,7 @@ func TestAppNexusBasicResponse(t *testing.T) {
 	req.Header.Add("User-Agent", andata.deviceUA)
 	req.Header.Add("X-Real-IP", andata.deviceIP)
 
-	pc := pbs.ParsePBSCookieFromRequest(req, config.Cookie{"", ""})
+	pc := pbs.ParsePBSCookieFromRequest(req, config.Cookie{})
 	pc.TrySync("adnxs", andata.buyerUID)
 	fakewriter := httptest.NewRecorder()
 	pc.SetCookieOnResponse(fakewriter, "")
@@ -337,7 +337,7 @@ func TestAppNexusBasicResponse(t *testing.T) {
 	cacheClient, _ := dummycache.New()
 	hcs := pbs.HostCookieSettings{}
 
-	pbReq, err := pbs.ParsePBSRequest(req, cacheClient, &hcs, config.Cookie{"", ""})
+	pbReq, err := pbs.ParsePBSRequest(req, cacheClient, &hcs, config.Cookie{})
 	if err != nil {
 		t.Fatalf("ParsePBSRequest failed: %v", err)
 	}

--- a/adapters/appnexus/appnexus_test.go
+++ b/adapters/appnexus/appnexus_test.go
@@ -327,7 +327,7 @@ func TestAppNexusBasicResponse(t *testing.T) {
 	req.Header.Add("User-Agent", andata.deviceUA)
 	req.Header.Add("X-Real-IP", andata.deviceIP)
 
-	pc := pbs.ParsePBSCookieFromRequest(req)
+	pc := pbs.ParsePBSCookieFromRequest(req, "trp_optout")
 	pc.TrySync("adnxs", andata.buyerUID)
 	fakewriter := httptest.NewRecorder()
 	pc.SetCookieOnResponse(fakewriter, "")
@@ -336,7 +336,7 @@ func TestAppNexusBasicResponse(t *testing.T) {
 	cacheClient, _ := dummycache.New()
 	hcs := pbs.HostCookieSettings{}
 
-	pbReq, err := pbs.ParsePBSRequest(req, cacheClient, &hcs)
+	pbReq, err := pbs.ParsePBSRequest(req, cacheClient, &hcs, "trp_optout")
 	if err != nil {
 		t.Fatalf("ParsePBSRequest failed: %v", err)
 	}

--- a/adapters/appnexus/appnexus_test.go
+++ b/adapters/appnexus/appnexus_test.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/mxmCherry/openrtb"
 	"github.com/prebid/prebid-server/adapters"
+	"github.com/prebid/prebid-server/config"
 )
 
 type anTagInfo struct {
@@ -327,7 +328,7 @@ func TestAppNexusBasicResponse(t *testing.T) {
 	req.Header.Add("User-Agent", andata.deviceUA)
 	req.Header.Add("X-Real-IP", andata.deviceIP)
 
-	pc := pbs.ParsePBSCookieFromRequest(req, "trp_optout")
+	pc := pbs.ParsePBSCookieFromRequest(req, config.Cookie{"", ""})
 	pc.TrySync("adnxs", andata.buyerUID)
 	fakewriter := httptest.NewRecorder()
 	pc.SetCookieOnResponse(fakewriter, "")
@@ -336,7 +337,7 @@ func TestAppNexusBasicResponse(t *testing.T) {
 	cacheClient, _ := dummycache.New()
 	hcs := pbs.HostCookieSettings{}
 
-	pbReq, err := pbs.ParsePBSRequest(req, cacheClient, &hcs, "trp_optout")
+	pbReq, err := pbs.ParsePBSRequest(req, cacheClient, &hcs, config.Cookie{"", ""})
 	if err != nil {
 		t.Fatalf("ParsePBSRequest failed: %v", err)
 	}

--- a/adapters/appnexus/appnexus_test.go
+++ b/adapters/appnexus/appnexus_test.go
@@ -328,7 +328,7 @@ func TestAppNexusBasicResponse(t *testing.T) {
 	req.Header.Add("User-Agent", andata.deviceUA)
 	req.Header.Add("X-Real-IP", andata.deviceIP)
 
-	pc := pbs.ParsePBSCookieFromRequest(req, config.Cookie{})
+	pc := pbs.ParsePBSCookieFromRequest(req, &config.Cookie{})
 	pc.TrySync("adnxs", andata.buyerUID)
 	fakewriter := httptest.NewRecorder()
 	pc.SetCookieOnResponse(fakewriter, "")
@@ -337,7 +337,7 @@ func TestAppNexusBasicResponse(t *testing.T) {
 	cacheClient, _ := dummycache.New()
 	hcs := pbs.HostCookieSettings{}
 
-	pbReq, err := pbs.ParsePBSRequest(req, cacheClient, &hcs, config.Cookie{})
+	pbReq, err := pbs.ParsePBSRequest(req, cacheClient, &hcs, &config.Cookie{})
 	if err != nil {
 		t.Fatalf("ParsePBSRequest failed: %v", err)
 	}

--- a/adapters/facebook/facebook_test.go
+++ b/adapters/facebook/facebook_test.go
@@ -205,7 +205,7 @@ func GenerateBidRequestForTestData(fbdata bidInfo, url string) (*pbs.PBSRequest,
 	req.Header.Add("User-Agent", fbdata.deviceUA)
 	req.Header.Add("X-Real-IP", fbdata.deviceIP)
 
-	pc := pbs.ParsePBSCookieFromRequest(req, config.Cookie{})
+	pc := pbs.ParsePBSCookieFromRequest(req, &config.Cookie{})
 	pc.TrySync("audienceNetwork", fbdata.buyerUID)
 	fakewriter := httptest.NewRecorder()
 	pc.SetCookieOnResponse(fakewriter, "")
@@ -214,7 +214,7 @@ func GenerateBidRequestForTestData(fbdata bidInfo, url string) (*pbs.PBSRequest,
 	cacheClient, _ := dummycache.New()
 	hcs := pbs.HostCookieSettings{}
 
-	pbReq, err := pbs.ParsePBSRequest(req, cacheClient, &hcs, config.Cookie{})
+	pbReq, err := pbs.ParsePBSRequest(req, cacheClient, &hcs, &config.Cookie{})
 	return pbReq, err
 }
 

--- a/adapters/facebook/facebook_test.go
+++ b/adapters/facebook/facebook_test.go
@@ -204,7 +204,7 @@ func GenerateBidRequestForTestData(fbdata bidInfo, url string) (*pbs.PBSRequest,
 	req.Header.Add("User-Agent", fbdata.deviceUA)
 	req.Header.Add("X-Real-IP", fbdata.deviceIP)
 
-	pc := pbs.ParsePBSCookieFromRequest(req)
+	pc := pbs.ParsePBSCookieFromRequest(req, "trp_optout")
 	pc.TrySync("audienceNetwork", fbdata.buyerUID)
 	fakewriter := httptest.NewRecorder()
 	pc.SetCookieOnResponse(fakewriter, "")
@@ -213,7 +213,7 @@ func GenerateBidRequestForTestData(fbdata bidInfo, url string) (*pbs.PBSRequest,
 	cacheClient, _ := dummycache.New()
 	hcs := pbs.HostCookieSettings{}
 
-	pbReq, err := pbs.ParsePBSRequest(req, cacheClient, &hcs)
+	pbReq, err := pbs.ParsePBSRequest(req, cacheClient, &hcs, "trp_optout")
 	return pbReq, err
 }
 

--- a/adapters/facebook/facebook_test.go
+++ b/adapters/facebook/facebook_test.go
@@ -205,7 +205,7 @@ func GenerateBidRequestForTestData(fbdata bidInfo, url string) (*pbs.PBSRequest,
 	req.Header.Add("User-Agent", fbdata.deviceUA)
 	req.Header.Add("X-Real-IP", fbdata.deviceIP)
 
-	pc := pbs.ParsePBSCookieFromRequest(req, config.Cookie{"", ""})
+	pc := pbs.ParsePBSCookieFromRequest(req, config.Cookie{})
 	pc.TrySync("audienceNetwork", fbdata.buyerUID)
 	fakewriter := httptest.NewRecorder()
 	pc.SetCookieOnResponse(fakewriter, "")
@@ -214,7 +214,7 @@ func GenerateBidRequestForTestData(fbdata bidInfo, url string) (*pbs.PBSRequest,
 	cacheClient, _ := dummycache.New()
 	hcs := pbs.HostCookieSettings{}
 
-	pbReq, err := pbs.ParsePBSRequest(req, cacheClient, &hcs, config.Cookie{"", ""})
+	pbReq, err := pbs.ParsePBSRequest(req, cacheClient, &hcs, config.Cookie{})
 	return pbReq, err
 }
 

--- a/adapters/facebook/facebook_test.go
+++ b/adapters/facebook/facebook_test.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/mxmCherry/openrtb"
 	"github.com/prebid/prebid-server/adapters"
+	"github.com/prebid/prebid-server/config"
 )
 
 type tagInfo struct {
@@ -204,7 +205,7 @@ func GenerateBidRequestForTestData(fbdata bidInfo, url string) (*pbs.PBSRequest,
 	req.Header.Add("User-Agent", fbdata.deviceUA)
 	req.Header.Add("X-Real-IP", fbdata.deviceIP)
 
-	pc := pbs.ParsePBSCookieFromRequest(req, "trp_optout")
+	pc := pbs.ParsePBSCookieFromRequest(req, config.Cookie{"", ""})
 	pc.TrySync("audienceNetwork", fbdata.buyerUID)
 	fakewriter := httptest.NewRecorder()
 	pc.SetCookieOnResponse(fakewriter, "")
@@ -213,7 +214,7 @@ func GenerateBidRequestForTestData(fbdata bidInfo, url string) (*pbs.PBSRequest,
 	cacheClient, _ := dummycache.New()
 	hcs := pbs.HostCookieSettings{}
 
-	pbReq, err := pbs.ParsePBSRequest(req, cacheClient, &hcs, "trp_optout")
+	pbReq, err := pbs.ParsePBSRequest(req, cacheClient, &hcs, config.Cookie{"", ""})
 	return pbReq, err
 }
 

--- a/adapters/lifestreet/lifestreet_test.go
+++ b/adapters/lifestreet/lifestreet_test.go
@@ -224,14 +224,14 @@ func TestLifestreetBasicResponse(t *testing.T) {
 	req.Header.Add("Referer", lsdata.referrer)
 	req.Header.Add("X-Real-IP", lsdata.deviceIP)
 
-	pc := pbs.ParsePBSCookieFromRequest(req, config.Cookie{})
+	pc := pbs.ParsePBSCookieFromRequest(req, &config.Cookie{})
 	fakewriter := httptest.NewRecorder()
 	pc.SetCookieOnResponse(fakewriter, "")
 	req.Header.Add("Cookie", fakewriter.Header().Get("Set-Cookie"))
 
 	cacheClient, _ := dummycache.New()
 	hcs := pbs.HostCookieSettings{}
-	pbReq, err := pbs.ParsePBSRequest(req, cacheClient, &hcs, config.Cookie{})
+	pbReq, err := pbs.ParsePBSRequest(req, cacheClient, &hcs, &config.Cookie{})
 	if err != nil {
 		t.Fatalf("ParsePBSRequest failed: %v", err)
 	}

--- a/adapters/lifestreet/lifestreet_test.go
+++ b/adapters/lifestreet/lifestreet_test.go
@@ -223,14 +223,14 @@ func TestLifestreetBasicResponse(t *testing.T) {
 	req.Header.Add("Referer", lsdata.referrer)
 	req.Header.Add("X-Real-IP", lsdata.deviceIP)
 
-	pc := pbs.ParsePBSCookieFromRequest(req)
+	pc := pbs.ParsePBSCookieFromRequest(req, "trp_optout")
 	fakewriter := httptest.NewRecorder()
 	pc.SetCookieOnResponse(fakewriter, "")
 	req.Header.Add("Cookie", fakewriter.Header().Get("Set-Cookie"))
 
 	cacheClient, _ := dummycache.New()
 	hcs := pbs.HostCookieSettings{}
-	pbReq, err := pbs.ParsePBSRequest(req, cacheClient, &hcs)
+	pbReq, err := pbs.ParsePBSRequest(req, cacheClient, &hcs, "trp_optout")
 	if err != nil {
 		t.Fatalf("ParsePBSRequest failed: %v", err)
 	}

--- a/adapters/lifestreet/lifestreet_test.go
+++ b/adapters/lifestreet/lifestreet_test.go
@@ -224,14 +224,14 @@ func TestLifestreetBasicResponse(t *testing.T) {
 	req.Header.Add("Referer", lsdata.referrer)
 	req.Header.Add("X-Real-IP", lsdata.deviceIP)
 
-	pc := pbs.ParsePBSCookieFromRequest(req, config.Cookie{"", ""})
+	pc := pbs.ParsePBSCookieFromRequest(req, config.Cookie{})
 	fakewriter := httptest.NewRecorder()
 	pc.SetCookieOnResponse(fakewriter, "")
 	req.Header.Add("Cookie", fakewriter.Header().Get("Set-Cookie"))
 
 	cacheClient, _ := dummycache.New()
 	hcs := pbs.HostCookieSettings{}
-	pbReq, err := pbs.ParsePBSRequest(req, cacheClient, &hcs, config.Cookie{"", ""})
+	pbReq, err := pbs.ParsePBSRequest(req, cacheClient, &hcs, config.Cookie{})
 	if err != nil {
 		t.Fatalf("ParsePBSRequest failed: %v", err)
 	}

--- a/adapters/lifestreet/lifestreet_test.go
+++ b/adapters/lifestreet/lifestreet_test.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/mxmCherry/openrtb"
 	"github.com/prebid/prebid-server/adapters"
+	"github.com/prebid/prebid-server/config"
 )
 
 type lsTagInfo struct {
@@ -223,14 +224,14 @@ func TestLifestreetBasicResponse(t *testing.T) {
 	req.Header.Add("Referer", lsdata.referrer)
 	req.Header.Add("X-Real-IP", lsdata.deviceIP)
 
-	pc := pbs.ParsePBSCookieFromRequest(req, "trp_optout")
+	pc := pbs.ParsePBSCookieFromRequest(req, config.Cookie{"", ""})
 	fakewriter := httptest.NewRecorder()
 	pc.SetCookieOnResponse(fakewriter, "")
 	req.Header.Add("Cookie", fakewriter.Header().Get("Set-Cookie"))
 
 	cacheClient, _ := dummycache.New()
 	hcs := pbs.HostCookieSettings{}
-	pbReq, err := pbs.ParsePBSRequest(req, cacheClient, &hcs, "trp_optout")
+	pbReq, err := pbs.ParsePBSRequest(req, cacheClient, &hcs, config.Cookie{"", ""})
 	if err != nil {
 		t.Fatalf("ParsePBSRequest failed: %v", err)
 	}

--- a/adapters/openrtb_util_test.go
+++ b/adapters/openrtb_util_test.go
@@ -370,7 +370,7 @@ func TestOpenRTBEmptyUser(t *testing.T) {
 }
 
 func TestOpenRTBUserWithCookie(t *testing.T) {
-	pbsCookie := pbs.NewPBSCookie()
+	pbsCookie := pbs.NewPBSCookie(false)
 	pbsCookie.TrySync("test", "abcde")
 	pbReq := pbs.PBSRequest{
 		User: &openrtb.User{},

--- a/adapters/openrtb_util_test.go
+++ b/adapters/openrtb_util_test.go
@@ -370,7 +370,7 @@ func TestOpenRTBEmptyUser(t *testing.T) {
 }
 
 func TestOpenRTBUserWithCookie(t *testing.T) {
-	pbsCookie := pbs.NewPBSCookie(false)
+	pbsCookie := pbs.NewPBSCookie()
 	pbsCookie.TrySync("test", "abcde")
 	pbReq := pbs.PBSRequest{
 		User: &openrtb.User{},

--- a/adapters/pubmatic/pubmatic_test.go
+++ b/adapters/pubmatic/pubmatic_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/mxmCherry/openrtb"
 	"github.com/prebid/prebid-server/adapters"
 	"github.com/prebid/prebid-server/cache/dummycache"
+	"github.com/prebid/prebid-server/config"
 	"github.com/prebid/prebid-server/pbs"
 )
 
@@ -644,7 +645,7 @@ func TestPubmaticSampleRequest(t *testing.T) {
 
 	httpReq := httptest.NewRequest("POST", server.URL, body)
 	httpReq.Header.Add("Referer", "http://test.com/sports")
-	pc := pbs.ParsePBSCookieFromRequest(httpReq, "trp_optout")
+	pc := pbs.ParsePBSCookieFromRequest(httpReq, config.Cookie{"", ""})
 	pc.TrySync("pubmatic", "12345")
 	fakewriter := httptest.NewRecorder()
 	pc.SetCookieOnResponse(fakewriter, "")
@@ -653,7 +654,7 @@ func TestPubmaticSampleRequest(t *testing.T) {
 	cacheClient, _ := dummycache.New()
 	hcs := pbs.HostCookieSettings{}
 
-	_, err = pbs.ParsePBSRequest(httpReq, cacheClient, &hcs, "trp_optout")
+	_, err = pbs.ParsePBSRequest(httpReq, cacheClient, &hcs, config.Cookie{"", ""})
 	if err != nil {
 		t.Fatalf("Error when parsing request: %v", err)
 	}

--- a/adapters/pubmatic/pubmatic_test.go
+++ b/adapters/pubmatic/pubmatic_test.go
@@ -645,7 +645,7 @@ func TestPubmaticSampleRequest(t *testing.T) {
 
 	httpReq := httptest.NewRequest("POST", server.URL, body)
 	httpReq.Header.Add("Referer", "http://test.com/sports")
-	pc := pbs.ParsePBSCookieFromRequest(httpReq, config.Cookie{})
+	pc := pbs.ParsePBSCookieFromRequest(httpReq, &config.Cookie{})
 	pc.TrySync("pubmatic", "12345")
 	fakewriter := httptest.NewRecorder()
 	pc.SetCookieOnResponse(fakewriter, "")
@@ -654,7 +654,7 @@ func TestPubmaticSampleRequest(t *testing.T) {
 	cacheClient, _ := dummycache.New()
 	hcs := pbs.HostCookieSettings{}
 
-	_, err = pbs.ParsePBSRequest(httpReq, cacheClient, &hcs, config.Cookie{})
+	_, err = pbs.ParsePBSRequest(httpReq, cacheClient, &hcs, &config.Cookie{})
 	if err != nil {
 		t.Fatalf("Error when parsing request: %v", err)
 	}

--- a/adapters/pubmatic/pubmatic_test.go
+++ b/adapters/pubmatic/pubmatic_test.go
@@ -645,7 +645,7 @@ func TestPubmaticSampleRequest(t *testing.T) {
 
 	httpReq := httptest.NewRequest("POST", server.URL, body)
 	httpReq.Header.Add("Referer", "http://test.com/sports")
-	pc := pbs.ParsePBSCookieFromRequest(httpReq, config.Cookie{"", ""})
+	pc := pbs.ParsePBSCookieFromRequest(httpReq, config.Cookie{})
 	pc.TrySync("pubmatic", "12345")
 	fakewriter := httptest.NewRecorder()
 	pc.SetCookieOnResponse(fakewriter, "")
@@ -654,7 +654,7 @@ func TestPubmaticSampleRequest(t *testing.T) {
 	cacheClient, _ := dummycache.New()
 	hcs := pbs.HostCookieSettings{}
 
-	_, err = pbs.ParsePBSRequest(httpReq, cacheClient, &hcs, config.Cookie{"", ""})
+	_, err = pbs.ParsePBSRequest(httpReq, cacheClient, &hcs, config.Cookie{})
 	if err != nil {
 		t.Fatalf("Error when parsing request: %v", err)
 	}

--- a/adapters/pubmatic/pubmatic_test.go
+++ b/adapters/pubmatic/pubmatic_test.go
@@ -644,7 +644,7 @@ func TestPubmaticSampleRequest(t *testing.T) {
 
 	httpReq := httptest.NewRequest("POST", server.URL, body)
 	httpReq.Header.Add("Referer", "http://test.com/sports")
-	pc := pbs.ParsePBSCookieFromRequest(httpReq)
+	pc := pbs.ParsePBSCookieFromRequest(httpReq, "trp_optout")
 	pc.TrySync("pubmatic", "12345")
 	fakewriter := httptest.NewRecorder()
 	pc.SetCookieOnResponse(fakewriter, "")
@@ -653,7 +653,7 @@ func TestPubmaticSampleRequest(t *testing.T) {
 	cacheClient, _ := dummycache.New()
 	hcs := pbs.HostCookieSettings{}
 
-	_, err = pbs.ParsePBSRequest(httpReq, cacheClient, &hcs)
+	_, err = pbs.ParsePBSRequest(httpReq, cacheClient, &hcs, "trp_optout")
 	if err != nil {
 		t.Fatalf("Error when parsing request: %v", err)
 	}

--- a/adapters/pulsepoint/pulsepoint_test.go
+++ b/adapters/pulsepoint/pulsepoint_test.go
@@ -265,7 +265,7 @@ func SampleRequest(numberOfImpressions int, t *testing.T) *pbs.PBSRequest {
 	// setup a http request
 	httpReq := httptest.NewRequest("POST", CreateService(BidOnTags("")).Server.URL, body)
 	httpReq.Header.Add("Referer", "http://news.pub/topnews")
-	pc := pbs.ParsePBSCookieFromRequest(httpReq)
+	pc := pbs.ParsePBSCookieFromRequest(httpReq, "trp_optout")
 	pc.TrySync("pulsepoint", "pulsepointUser123")
 	fakewriter := httptest.NewRecorder()
 	pc.SetCookieOnResponse(fakewriter, "")
@@ -274,7 +274,7 @@ func SampleRequest(numberOfImpressions int, t *testing.T) *pbs.PBSRequest {
 	cacheClient, _ := dummycache.New()
 	hcs := pbs.HostCookieSettings{}
 
-	parsedReq, err := pbs.ParsePBSRequest(httpReq, cacheClient, &hcs)
+	parsedReq, err := pbs.ParsePBSRequest(httpReq, cacheClient, &hcs, "trp_optout")
 	if err != nil {
 		t.Fatalf("Error when parsing request: %v", err)
 	}

--- a/adapters/pulsepoint/pulsepoint_test.go
+++ b/adapters/pulsepoint/pulsepoint_test.go
@@ -266,7 +266,7 @@ func SampleRequest(numberOfImpressions int, t *testing.T) *pbs.PBSRequest {
 	// setup a http request
 	httpReq := httptest.NewRequest("POST", CreateService(BidOnTags("")).Server.URL, body)
 	httpReq.Header.Add("Referer", "http://news.pub/topnews")
-	pc := pbs.ParsePBSCookieFromRequest(httpReq, config.Cookie{})
+	pc := pbs.ParsePBSCookieFromRequest(httpReq, &config.Cookie{})
 	pc.TrySync("pulsepoint", "pulsepointUser123")
 	fakewriter := httptest.NewRecorder()
 	pc.SetCookieOnResponse(fakewriter, "")
@@ -275,7 +275,7 @@ func SampleRequest(numberOfImpressions int, t *testing.T) *pbs.PBSRequest {
 	cacheClient, _ := dummycache.New()
 	hcs := pbs.HostCookieSettings{}
 
-	parsedReq, err := pbs.ParsePBSRequest(httpReq, cacheClient, &hcs, config.Cookie{})
+	parsedReq, err := pbs.ParsePBSRequest(httpReq, cacheClient, &hcs, &config.Cookie{})
 	if err != nil {
 		t.Fatalf("Error when parsing request: %v", err)
 	}

--- a/adapters/pulsepoint/pulsepoint_test.go
+++ b/adapters/pulsepoint/pulsepoint_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/mxmCherry/openrtb"
 	"github.com/prebid/prebid-server/adapters"
 	"github.com/prebid/prebid-server/cache/dummycache"
+	"github.com/prebid/prebid-server/config"
 	"github.com/prebid/prebid-server/pbs"
 )
 
@@ -265,7 +266,7 @@ func SampleRequest(numberOfImpressions int, t *testing.T) *pbs.PBSRequest {
 	// setup a http request
 	httpReq := httptest.NewRequest("POST", CreateService(BidOnTags("")).Server.URL, body)
 	httpReq.Header.Add("Referer", "http://news.pub/topnews")
-	pc := pbs.ParsePBSCookieFromRequest(httpReq, "trp_optout")
+	pc := pbs.ParsePBSCookieFromRequest(httpReq, config.Cookie{"", ""})
 	pc.TrySync("pulsepoint", "pulsepointUser123")
 	fakewriter := httptest.NewRecorder()
 	pc.SetCookieOnResponse(fakewriter, "")
@@ -274,7 +275,7 @@ func SampleRequest(numberOfImpressions int, t *testing.T) *pbs.PBSRequest {
 	cacheClient, _ := dummycache.New()
 	hcs := pbs.HostCookieSettings{}
 
-	parsedReq, err := pbs.ParsePBSRequest(httpReq, cacheClient, &hcs, "trp_optout")
+	parsedReq, err := pbs.ParsePBSRequest(httpReq, cacheClient, &hcs, config.Cookie{"", ""})
 	if err != nil {
 		t.Fatalf("Error when parsing request: %v", err)
 	}

--- a/adapters/pulsepoint/pulsepoint_test.go
+++ b/adapters/pulsepoint/pulsepoint_test.go
@@ -266,7 +266,7 @@ func SampleRequest(numberOfImpressions int, t *testing.T) *pbs.PBSRequest {
 	// setup a http request
 	httpReq := httptest.NewRequest("POST", CreateService(BidOnTags("")).Server.URL, body)
 	httpReq.Header.Add("Referer", "http://news.pub/topnews")
-	pc := pbs.ParsePBSCookieFromRequest(httpReq, config.Cookie{"", ""})
+	pc := pbs.ParsePBSCookieFromRequest(httpReq, config.Cookie{})
 	pc.TrySync("pulsepoint", "pulsepointUser123")
 	fakewriter := httptest.NewRecorder()
 	pc.SetCookieOnResponse(fakewriter, "")
@@ -275,7 +275,7 @@ func SampleRequest(numberOfImpressions int, t *testing.T) *pbs.PBSRequest {
 	cacheClient, _ := dummycache.New()
 	hcs := pbs.HostCookieSettings{}
 
-	parsedReq, err := pbs.ParsePBSRequest(httpReq, cacheClient, &hcs, config.Cookie{"", ""})
+	parsedReq, err := pbs.ParsePBSRequest(httpReq, cacheClient, &hcs, config.Cookie{})
 	if err != nil {
 		t.Fatalf("Error when parsing request: %v", err)
 	}

--- a/adapters/rubicon/rubicon_test.go
+++ b/adapters/rubicon/rubicon_test.go
@@ -297,7 +297,7 @@ func TestRubiconBasicResponse(t *testing.T) {
 	req.Header.Add("User-Agent", rubidata.deviceUA)
 	req.Header.Add("X-Real-IP", rubidata.deviceIP)
 
-	pc := pbs.ParsePBSCookieFromRequest(req, config.Cookie{"", ""})
+	pc := pbs.ParsePBSCookieFromRequest(req, config.Cookie{})
 	pc.TrySync("rubicon", rubidata.buyerUID)
 	fakewriter := httptest.NewRecorder()
 	pc.SetCookieOnResponse(fakewriter, "")
@@ -306,7 +306,7 @@ func TestRubiconBasicResponse(t *testing.T) {
 	cacheClient, _ := dummycache.New()
 	hcs := pbs.HostCookieSettings{}
 
-	pbReq, err := pbs.ParsePBSRequest(req, cacheClient, &hcs, config.Cookie{"", ""})
+	pbReq, err := pbs.ParsePBSRequest(req, cacheClient, &hcs, config.Cookie{})
 	if err != nil {
 		t.Fatalf("ParsePBSRequest failed: %v", err)
 	}

--- a/adapters/rubicon/rubicon_test.go
+++ b/adapters/rubicon/rubicon_test.go
@@ -297,7 +297,7 @@ func TestRubiconBasicResponse(t *testing.T) {
 	req.Header.Add("User-Agent", rubidata.deviceUA)
 	req.Header.Add("X-Real-IP", rubidata.deviceIP)
 
-	pc := pbs.ParsePBSCookieFromRequest(req, config.Cookie{})
+	pc := pbs.ParsePBSCookieFromRequest(req, &config.Cookie{})
 	pc.TrySync("rubicon", rubidata.buyerUID)
 	fakewriter := httptest.NewRecorder()
 	pc.SetCookieOnResponse(fakewriter, "")
@@ -306,7 +306,7 @@ func TestRubiconBasicResponse(t *testing.T) {
 	cacheClient, _ := dummycache.New()
 	hcs := pbs.HostCookieSettings{}
 
-	pbReq, err := pbs.ParsePBSRequest(req, cacheClient, &hcs, config.Cookie{})
+	pbReq, err := pbs.ParsePBSRequest(req, cacheClient, &hcs, &config.Cookie{})
 	if err != nil {
 		t.Fatalf("ParsePBSRequest failed: %v", err)
 	}

--- a/adapters/rubicon/rubicon_test.go
+++ b/adapters/rubicon/rubicon_test.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/mxmCherry/openrtb"
 	"github.com/prebid/prebid-server/adapters"
+	"github.com/prebid/prebid-server/config"
 )
 
 type rubiAppendTrackerUrlTestScenario struct {
@@ -296,7 +297,7 @@ func TestRubiconBasicResponse(t *testing.T) {
 	req.Header.Add("User-Agent", rubidata.deviceUA)
 	req.Header.Add("X-Real-IP", rubidata.deviceIP)
 
-	pc := pbs.ParsePBSCookieFromRequest(req, "trp_optout")
+	pc := pbs.ParsePBSCookieFromRequest(req, config.Cookie{"", ""})
 	pc.TrySync("rubicon", rubidata.buyerUID)
 	fakewriter := httptest.NewRecorder()
 	pc.SetCookieOnResponse(fakewriter, "")
@@ -305,7 +306,7 @@ func TestRubiconBasicResponse(t *testing.T) {
 	cacheClient, _ := dummycache.New()
 	hcs := pbs.HostCookieSettings{}
 
-	pbReq, err := pbs.ParsePBSRequest(req, cacheClient, &hcs, "trp_optout")
+	pbReq, err := pbs.ParsePBSRequest(req, cacheClient, &hcs, config.Cookie{"", ""})
 	if err != nil {
 		t.Fatalf("ParsePBSRequest failed: %v", err)
 	}

--- a/adapters/rubicon/rubicon_test.go
+++ b/adapters/rubicon/rubicon_test.go
@@ -296,7 +296,7 @@ func TestRubiconBasicResponse(t *testing.T) {
 	req.Header.Add("User-Agent", rubidata.deviceUA)
 	req.Header.Add("X-Real-IP", rubidata.deviceIP)
 
-	pc := pbs.ParsePBSCookieFromRequest(req)
+	pc := pbs.ParsePBSCookieFromRequest(req, "trp_optout")
 	pc.TrySync("rubicon", rubidata.buyerUID)
 	fakewriter := httptest.NewRecorder()
 	pc.SetCookieOnResponse(fakewriter, "")
@@ -305,7 +305,7 @@ func TestRubiconBasicResponse(t *testing.T) {
 	cacheClient, _ := dummycache.New()
 	hcs := pbs.HostCookieSettings{}
 
-	pbReq, err := pbs.ParsePBSRequest(req, cacheClient, &hcs)
+	pbReq, err := pbs.ParsePBSRequest(req, cacheClient, &hcs, "trp_optout")
 	if err != nil {
 		t.Fatalf("ParsePBSRequest failed: %v", err)
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -19,6 +19,7 @@ type Configuration struct {
 	Metrics         Metrics            `mapstructure:"metrics"`
 	DataCache       DataCache          `mapstructure:"datacache"`
 	Adapters        map[string]Adapter `mapstructure:"adapters"`
+	OptOutCookieName string            `mapstructure:"optout_cookie_name"`
 }
 
 type HostCookie struct {

--- a/config/config.go
+++ b/config/config.go
@@ -19,7 +19,7 @@ type Configuration struct {
 	Metrics         Metrics            `mapstructure:"metrics"`
 	DataCache       DataCache          `mapstructure:"datacache"`
 	Adapters        map[string]Adapter `mapstructure:"adapters"`
-	OptOutCookieName string            `mapstructure:"optout_cookie_name"`
+	OptOutCookie    Cookie             `mapstructure:"optout_cookie"`
 }
 
 type HostCookie struct {
@@ -34,11 +34,11 @@ type Adapter struct {
 	Endpoint    string `mapstructure:"endpoint"` // Required
 	UserSyncURL string `mapstructure:"usersync_url"`
 	PlatformID  string `mapstructure:"platform_id"` // needed for Facebook
-	XAPI        struct {
+	XAPI struct {
 		Username string `mapstructure:"username"`
 		Password string `mapstructure:"password"`
 		Tracker  string `mapstructure:"tracker"`
-	} `mapstructure:"xapi"` // needed for Rubicon
+	} `mapstructure:"xapi"`                         // needed for Rubicon
 }
 
 type Metrics struct {
@@ -65,6 +65,11 @@ type Cache struct {
 	Query  string `mapstructure:"query"`
 }
 
+type Cookie struct {
+	Name  string `mapstructure:"name"`
+	Value string `mapstructure:"value"`
+}
+
 // New uses viper to get our server configurations
 func New() (*Configuration, error) {
 	var c Configuration
@@ -77,10 +82,10 @@ func New() (*Configuration, error) {
 //Allows for protocol relative URL if scheme is empty
 func (cfg *Configuration) GetCacheBaseURL() string {
 	cfg.CacheURL.Scheme = strings.ToLower(cfg.CacheURL.Scheme)
-	if strings.Contains(cfg.CacheURL.Scheme, "https"){
+	if strings.Contains(cfg.CacheURL.Scheme, "https") {
 		return fmt.Sprintf("https://%s", cfg.CacheURL.Host)
 	}
-	if strings.Contains(cfg.CacheURL.Scheme, "http"){
+	if strings.Contains(cfg.CacheURL.Scheme, "http") {
 		return fmt.Sprintf("http://%s", cfg.CacheURL.Host)
 	}
 	return fmt.Sprintf("//%s", cfg.CacheURL.Host)

--- a/config/config.go
+++ b/config/config.go
@@ -34,11 +34,11 @@ type Adapter struct {
 	Endpoint    string `mapstructure:"endpoint"` // Required
 	UserSyncURL string `mapstructure:"usersync_url"`
 	PlatformID  string `mapstructure:"platform_id"` // needed for Facebook
-	XAPI struct {
+	XAPI        struct {
 		Username string `mapstructure:"username"`
 		Password string `mapstructure:"password"`
 		Tracker  string `mapstructure:"tracker"`
-	} `mapstructure:"xapi"`                         // needed for Rubicon
+	} `mapstructure:"xapi"` // needed for Rubicon
 }
 
 type Metrics struct {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -158,4 +158,3 @@ func TestFullConfig(t *testing.T) {
 	cmpStrings(t, "adapters.facebook.usersync_url", cfg.Adapters["facebook"].UserSyncURL, "http://facebook.com/ortb/prebid-s2s")
 	cmpStrings(t, "adapters.facebook.platform_id", cfg.Adapters["facebook"].PlatformID, "abcdefgh1234")
 }
-

--- a/pbs/pbsrequest.go
+++ b/pbs/pbsrequest.go
@@ -211,7 +211,7 @@ func ParseMediaTypes(types []string) []MediaType {
 	return mtypes
 }
 
-func ParsePBSRequest(r *http.Request, cache cache.Cache, hostCookieSettings *HostCookieSettings) (*PBSRequest, error) {
+func ParsePBSRequest(r *http.Request, cache cache.Cache, hostCookieSettings *HostCookieSettings, optOutCookieName string) (*PBSRequest, error) {
 	defer r.Body.Close()
 
 	pbsReq := &PBSRequest{}
@@ -258,7 +258,7 @@ func ParsePBSRequest(r *http.Request, cache cache.Cache, hostCookieSettings *Hos
 
 	// use client-side data for web requests
 	if pbsReq.App == nil {
-		pbsReq.Cookie = ParsePBSCookieFromRequest(r)
+		pbsReq.Cookie = ParsePBSCookieFromRequest(r, optOutCookieName)
 
 		// Host has right to leverage private cookie store for user ID
 		if uid, _, _ := pbsReq.Cookie.GetUID(hostCookieSettings.Family); uid == "" && hostCookieSettings.CookieName != "" {

--- a/pbs/pbsrequest.go
+++ b/pbs/pbsrequest.go
@@ -212,7 +212,7 @@ func ParseMediaTypes(types []string) []MediaType {
 	return mtypes
 }
 
-func ParsePBSRequest(r *http.Request, cache cache.Cache, hostCookieSettings *HostCookieSettings, optOutCookie config.Cookie) (*PBSRequest, error) {
+func ParsePBSRequest(r *http.Request, cache cache.Cache, hostCookieSettings *HostCookieSettings, optOutCookie *config.Cookie) (*PBSRequest, error) {
 	defer r.Body.Close()
 
 	pbsReq := &PBSRequest{}

--- a/pbs/pbsrequest.go
+++ b/pbs/pbsrequest.go
@@ -16,8 +16,8 @@ import (
 	"github.com/blang/semver"
 	"github.com/mxmCherry/openrtb"
 	"github.com/prebid/prebid-server/cache"
-	"github.com/prebid/prebid-server/prebid"
 	"github.com/prebid/prebid-server/config"
+	"github.com/prebid/prebid-server/prebid"
 )
 
 const MAX_BIDDERS = 8

--- a/pbs/pbsrequest.go
+++ b/pbs/pbsrequest.go
@@ -17,6 +17,7 @@ import (
 	"github.com/mxmCherry/openrtb"
 	"github.com/prebid/prebid-server/cache"
 	"github.com/prebid/prebid-server/prebid"
+	"github.com/prebid/prebid-server/config"
 )
 
 const MAX_BIDDERS = 8
@@ -211,7 +212,7 @@ func ParseMediaTypes(types []string) []MediaType {
 	return mtypes
 }
 
-func ParsePBSRequest(r *http.Request, cache cache.Cache, hostCookieSettings *HostCookieSettings, optOutCookieName string) (*PBSRequest, error) {
+func ParsePBSRequest(r *http.Request, cache cache.Cache, hostCookieSettings *HostCookieSettings, optOutCookie config.Cookie) (*PBSRequest, error) {
 	defer r.Body.Close()
 
 	pbsReq := &PBSRequest{}
@@ -258,7 +259,7 @@ func ParsePBSRequest(r *http.Request, cache cache.Cache, hostCookieSettings *Hos
 
 	// use client-side data for web requests
 	if pbsReq.App == nil {
-		pbsReq.Cookie = ParsePBSCookieFromRequest(r, optOutCookieName)
+		pbsReq.Cookie = ParsePBSCookieFromRequest(r, optOutCookie)
 
 		// Host has right to leverage private cookie store for user ID
 		if uid, _, _ := pbsReq.Cookie.GetUID(hostCookieSettings.Family); uid == "" && hostCookieSettings.CookieName != "" {

--- a/pbs/pbsrequest_test.go
+++ b/pbs/pbsrequest_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/magiconair/properties/assert"
 	"github.com/prebid/prebid-server/cache/dummycache"
+	"github.com/prebid/prebid-server/config"
 )
 
 const mimeVideoMp4 = "video/mp4"
@@ -72,7 +73,7 @@ func TestParseSimpleRequest(t *testing.T) {
 	d, _ := dummycache.New()
 	hcs := HostCookieSettings{}
 
-	pbs_req, err := ParsePBSRequest(r, d, &hcs, "trp_optout")
+	pbs_req, err := ParsePBSRequest(r, d, &hcs, config.Cookie{"", ""})
 	if err != nil {
 		t.Fatalf("Parse simple request failed: %v", err)
 	}
@@ -154,7 +155,7 @@ func TestHeaderParsing(t *testing.T) {
 
 	d.Config().Set("dummy", dummyConfig)
 
-	pbs_req, err := ParsePBSRequest(r, d, &hcs, "trp_optout")
+	pbs_req, err := ParsePBSRequest(r, d, &hcs, config.Cookie{"", ""})
 	if err != nil {
 		t.Fatalf("Parse simple request failed")
 	}
@@ -236,7 +237,7 @@ func TestParseConfig(t *testing.T) {
 
 	d.Config().Set("dummy", dummyConfig)
 
-	pbs_req, err := ParsePBSRequest(r, d, &hcs, "trp_optout")
+	pbs_req, err := ParsePBSRequest(r, d, &hcs, config.Cookie{"", ""})
 	if err != nil {
 		t.Fatalf("Parse simple request failed: %v", err)
 	}
@@ -317,7 +318,7 @@ func TestParseMobileRequestFirstVersion(t *testing.T) {
 	d, _ := dummycache.New()
 	hcs := HostCookieSettings{}
 
-	pbs_req, err := ParsePBSRequest(r, d, &hcs, "trp_optout")
+	pbs_req, err := ParsePBSRequest(r, d, &hcs, config.Cookie{"", ""})
 	if err != nil {
 		t.Fatalf("Parse simple request failed: %v", err)
 	}
@@ -413,7 +414,7 @@ func TestParseMobileRequest(t *testing.T) {
 	d, _ := dummycache.New()
 	hcs := HostCookieSettings{}
 
-	pbs_req, err := ParsePBSRequest(r, d, &hcs, "trp_optout")
+	pbs_req, err := ParsePBSRequest(r, d, &hcs, config.Cookie{"", ""})
 	if err != nil {
 		t.Fatalf("Parse simple request failed: %v", err)
 	}
@@ -513,7 +514,7 @@ func TestParseMalformedMobileRequest(t *testing.T) {
 	d, _ := dummycache.New()
 	hcs := HostCookieSettings{}
 
-	pbs_req, err := ParsePBSRequest(r, d, &hcs, "trp_optout")
+	pbs_req, err := ParsePBSRequest(r, d, &hcs, config.Cookie{"", ""})
 	if err != nil {
 		t.Fatalf("Parse simple request failed: %v", err)
 	}
@@ -617,7 +618,7 @@ func TestParseRequestWithInstl(t *testing.T) {
 	d, _ := dummycache.New()
 	hcs := HostCookieSettings{}
 
-	pbs_req, err := ParsePBSRequest(r, d, &hcs, "trp_optout")
+	pbs_req, err := ParsePBSRequest(r, d, &hcs, config.Cookie{"", ""})
 	if err != nil {
 		t.Fatalf("Parse simple request failed: %v", err)
 	}
@@ -665,7 +666,7 @@ func TestParsePBSRequestUsesHostCookie(t *testing.T) {
 		Family:     "family",
 	}
 
-	pbs_req, err2 := ParsePBSRequest(r, d, &hcs, "trp_optout")
+	pbs_req, err2 := ParsePBSRequest(r, d, &hcs, config.Cookie{"trp_optout", "true"})
 	if err2 != nil {
 		t.Fatalf("Parse simple request failed %v", err2)
 	}

--- a/pbs/pbsrequest_test.go
+++ b/pbs/pbsrequest_test.go
@@ -73,7 +73,7 @@ func TestParseSimpleRequest(t *testing.T) {
 	d, _ := dummycache.New()
 	hcs := HostCookieSettings{}
 
-	pbs_req, err := ParsePBSRequest(r, d, &hcs, config.Cookie{"", ""})
+	pbs_req, err := ParsePBSRequest(r, d, &hcs, config.Cookie{})
 	if err != nil {
 		t.Fatalf("Parse simple request failed: %v", err)
 	}
@@ -155,7 +155,7 @@ func TestHeaderParsing(t *testing.T) {
 
 	d.Config().Set("dummy", dummyConfig)
 
-	pbs_req, err := ParsePBSRequest(r, d, &hcs, config.Cookie{"", ""})
+	pbs_req, err := ParsePBSRequest(r, d, &hcs, config.Cookie{})
 	if err != nil {
 		t.Fatalf("Parse simple request failed")
 	}
@@ -237,7 +237,7 @@ func TestParseConfig(t *testing.T) {
 
 	d.Config().Set("dummy", dummyConfig)
 
-	pbs_req, err := ParsePBSRequest(r, d, &hcs, config.Cookie{"", ""})
+	pbs_req, err := ParsePBSRequest(r, d, &hcs, config.Cookie{})
 	if err != nil {
 		t.Fatalf("Parse simple request failed: %v", err)
 	}
@@ -318,7 +318,7 @@ func TestParseMobileRequestFirstVersion(t *testing.T) {
 	d, _ := dummycache.New()
 	hcs := HostCookieSettings{}
 
-	pbs_req, err := ParsePBSRequest(r, d, &hcs, config.Cookie{"", ""})
+	pbs_req, err := ParsePBSRequest(r, d, &hcs, config.Cookie{})
 	if err != nil {
 		t.Fatalf("Parse simple request failed: %v", err)
 	}
@@ -414,7 +414,7 @@ func TestParseMobileRequest(t *testing.T) {
 	d, _ := dummycache.New()
 	hcs := HostCookieSettings{}
 
-	pbs_req, err := ParsePBSRequest(r, d, &hcs, config.Cookie{"", ""})
+	pbs_req, err := ParsePBSRequest(r, d, &hcs, config.Cookie{})
 	if err != nil {
 		t.Fatalf("Parse simple request failed: %v", err)
 	}
@@ -514,7 +514,7 @@ func TestParseMalformedMobileRequest(t *testing.T) {
 	d, _ := dummycache.New()
 	hcs := HostCookieSettings{}
 
-	pbs_req, err := ParsePBSRequest(r, d, &hcs, config.Cookie{"", ""})
+	pbs_req, err := ParsePBSRequest(r, d, &hcs, config.Cookie{})
 	if err != nil {
 		t.Fatalf("Parse simple request failed: %v", err)
 	}
@@ -618,7 +618,7 @@ func TestParseRequestWithInstl(t *testing.T) {
 	d, _ := dummycache.New()
 	hcs := HostCookieSettings{}
 
-	pbs_req, err := ParsePBSRequest(r, d, &hcs, config.Cookie{"", ""})
+	pbs_req, err := ParsePBSRequest(r, d, &hcs, config.Cookie{})
 	if err != nil {
 		t.Fatalf("Parse simple request failed: %v", err)
 	}

--- a/pbs/pbsrequest_test.go
+++ b/pbs/pbsrequest_test.go
@@ -72,7 +72,7 @@ func TestParseSimpleRequest(t *testing.T) {
 	d, _ := dummycache.New()
 	hcs := HostCookieSettings{}
 
-	pbs_req, err := ParsePBSRequest(r, d, &hcs)
+	pbs_req, err := ParsePBSRequest(r, d, &hcs, "trp_optout")
 	if err != nil {
 		t.Fatalf("Parse simple request failed: %v", err)
 	}
@@ -154,7 +154,7 @@ func TestHeaderParsing(t *testing.T) {
 
 	d.Config().Set("dummy", dummyConfig)
 
-	pbs_req, err := ParsePBSRequest(r, d, &hcs)
+	pbs_req, err := ParsePBSRequest(r, d, &hcs, "trp_optout")
 	if err != nil {
 		t.Fatalf("Parse simple request failed")
 	}
@@ -236,7 +236,7 @@ func TestParseConfig(t *testing.T) {
 
 	d.Config().Set("dummy", dummyConfig)
 
-	pbs_req, err := ParsePBSRequest(r, d, &hcs)
+	pbs_req, err := ParsePBSRequest(r, d, &hcs, "trp_optout")
 	if err != nil {
 		t.Fatalf("Parse simple request failed: %v", err)
 	}
@@ -317,7 +317,7 @@ func TestParseMobileRequestFirstVersion(t *testing.T) {
 	d, _ := dummycache.New()
 	hcs := HostCookieSettings{}
 
-	pbs_req, err := ParsePBSRequest(r, d, &hcs)
+	pbs_req, err := ParsePBSRequest(r, d, &hcs, "trp_optout")
 	if err != nil {
 		t.Fatalf("Parse simple request failed: %v", err)
 	}
@@ -413,7 +413,7 @@ func TestParseMobileRequest(t *testing.T) {
 	d, _ := dummycache.New()
 	hcs := HostCookieSettings{}
 
-	pbs_req, err := ParsePBSRequest(r, d, &hcs)
+	pbs_req, err := ParsePBSRequest(r, d, &hcs, "trp_optout")
 	if err != nil {
 		t.Fatalf("Parse simple request failed: %v", err)
 	}
@@ -513,7 +513,7 @@ func TestParseMalformedMobileRequest(t *testing.T) {
 	d, _ := dummycache.New()
 	hcs := HostCookieSettings{}
 
-	pbs_req, err := ParsePBSRequest(r, d, &hcs)
+	pbs_req, err := ParsePBSRequest(r, d, &hcs, "trp_optout")
 	if err != nil {
 		t.Fatalf("Parse simple request failed: %v", err)
 	}
@@ -617,7 +617,7 @@ func TestParseRequestWithInstl(t *testing.T) {
 	d, _ := dummycache.New()
 	hcs := HostCookieSettings{}
 
-	pbs_req, err := ParsePBSRequest(r, d, &hcs)
+	pbs_req, err := ParsePBSRequest(r, d, &hcs, "trp_optout")
 	if err != nil {
 		t.Fatalf("Parse simple request failed: %v", err)
 	}
@@ -665,7 +665,7 @@ func TestParsePBSRequestUsesHostCookie(t *testing.T) {
 		Family:     "family",
 	}
 
-	pbs_req, err2 := ParsePBSRequest(r, d, &hcs)
+	pbs_req, err2 := ParsePBSRequest(r, d, &hcs, "trp_optout")
 	if err2 != nil {
 		t.Fatalf("Parse simple request failed %v", err2)
 	}

--- a/pbs/pbsrequest_test.go
+++ b/pbs/pbsrequest_test.go
@@ -73,7 +73,7 @@ func TestParseSimpleRequest(t *testing.T) {
 	d, _ := dummycache.New()
 	hcs := HostCookieSettings{}
 
-	pbs_req, err := ParsePBSRequest(r, d, &hcs, config.Cookie{})
+	pbs_req, err := ParsePBSRequest(r, d, &hcs, &config.Cookie{})
 	if err != nil {
 		t.Fatalf("Parse simple request failed: %v", err)
 	}
@@ -155,7 +155,7 @@ func TestHeaderParsing(t *testing.T) {
 
 	d.Config().Set("dummy", dummyConfig)
 
-	pbs_req, err := ParsePBSRequest(r, d, &hcs, config.Cookie{})
+	pbs_req, err := ParsePBSRequest(r, d, &hcs, &config.Cookie{})
 	if err != nil {
 		t.Fatalf("Parse simple request failed")
 	}
@@ -237,7 +237,7 @@ func TestParseConfig(t *testing.T) {
 
 	d.Config().Set("dummy", dummyConfig)
 
-	pbs_req, err := ParsePBSRequest(r, d, &hcs, config.Cookie{})
+	pbs_req, err := ParsePBSRequest(r, d, &hcs, &config.Cookie{})
 	if err != nil {
 		t.Fatalf("Parse simple request failed: %v", err)
 	}
@@ -318,7 +318,7 @@ func TestParseMobileRequestFirstVersion(t *testing.T) {
 	d, _ := dummycache.New()
 	hcs := HostCookieSettings{}
 
-	pbs_req, err := ParsePBSRequest(r, d, &hcs, config.Cookie{})
+	pbs_req, err := ParsePBSRequest(r, d, &hcs, &config.Cookie{})
 	if err != nil {
 		t.Fatalf("Parse simple request failed: %v", err)
 	}
@@ -414,7 +414,7 @@ func TestParseMobileRequest(t *testing.T) {
 	d, _ := dummycache.New()
 	hcs := HostCookieSettings{}
 
-	pbs_req, err := ParsePBSRequest(r, d, &hcs, config.Cookie{})
+	pbs_req, err := ParsePBSRequest(r, d, &hcs, &config.Cookie{})
 	if err != nil {
 		t.Fatalf("Parse simple request failed: %v", err)
 	}
@@ -514,7 +514,7 @@ func TestParseMalformedMobileRequest(t *testing.T) {
 	d, _ := dummycache.New()
 	hcs := HostCookieSettings{}
 
-	pbs_req, err := ParsePBSRequest(r, d, &hcs, config.Cookie{})
+	pbs_req, err := ParsePBSRequest(r, d, &hcs, &config.Cookie{})
 	if err != nil {
 		t.Fatalf("Parse simple request failed: %v", err)
 	}
@@ -618,7 +618,7 @@ func TestParseRequestWithInstl(t *testing.T) {
 	d, _ := dummycache.New()
 	hcs := HostCookieSettings{}
 
-	pbs_req, err := ParsePBSRequest(r, d, &hcs, config.Cookie{})
+	pbs_req, err := ParsePBSRequest(r, d, &hcs, &config.Cookie{})
 	if err != nil {
 		t.Fatalf("Parse simple request failed: %v", err)
 	}
@@ -666,7 +666,7 @@ func TestParsePBSRequestUsesHostCookie(t *testing.T) {
 		Family:     "family",
 	}
 
-	pbs_req, err2 := ParsePBSRequest(r, d, &hcs, config.Cookie{"trp_optout", "true"})
+	pbs_req, err2 := ParsePBSRequest(r, d, &hcs, &config.Cookie{"trp_optout", "true"})
 	if err2 != nil {
 		t.Fatalf("Parse simple request failed %v", err2)
 	}

--- a/pbs/usersync.go
+++ b/pbs/usersync.go
@@ -73,10 +73,10 @@ type UserSyncDeps struct {
 }
 
 // ParsePBSCookieFromRequest parses the UserSyncMap from an HTTP Request.
-func ParsePBSCookieFromRequest(r *http.Request, optoutCookie config.Cookie) *PBSCookie {
-	if optoutCookie.Name != "" {
-		optOutCookie, err1 := r.Cookie(optoutCookie.Name)
-		if err1 == nil && optOutCookie.Value == optoutCookie.Value {
+func ParsePBSCookieFromRequest(r *http.Request, configuredOptoutCookie config.Cookie) *PBSCookie {
+	if configuredOptoutCookie.Name != "" {
+		optOutCookie, err1 := r.Cookie(configuredOptoutCookie.Name)
+		if err1 == nil && optOutCookie.Value == configuredOptoutCookie.Value {
 			pc := NewPBSCookie()
 			pc.SetPreference(false)
 			return pc

--- a/pbs/usersync.go
+++ b/pbs/usersync.go
@@ -73,7 +73,7 @@ type UserSyncDeps struct {
 }
 
 // ParsePBSCookieFromRequest parses the UserSyncMap from an HTTP Request.
-func ParsePBSCookieFromRequest(r *http.Request, configuredOptoutCookie config.Cookie) *PBSCookie {
+func ParsePBSCookieFromRequest(r *http.Request, configuredOptoutCookie *config.Cookie) *PBSCookie {
 	if configuredOptoutCookie.Name != "" {
 		optOutCookie, err1 := r.Cookie(configuredOptoutCookie.Name)
 		if err1 == nil && optOutCookie.Value == configuredOptoutCookie.Value {
@@ -278,7 +278,7 @@ func (cookie *PBSCookie) UnmarshalJSON(b []byte) error {
 }
 
 func (deps *UserSyncDeps) GetUIDs(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
-	pc := ParsePBSCookieFromRequest(r, deps.OptOutCookie)
+	pc := ParsePBSCookieFromRequest(r, &deps.OptOutCookie)
 	pc.SetCookieOnResponse(w, deps.HostCookieSettings.Domain)
 	json.NewEncoder(w).Encode(pc)
 	return
@@ -299,7 +299,7 @@ func getRawQueryMap(query string) map[string]string {
 }
 
 func (deps *UserSyncDeps) SetUID(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
-	pc := ParsePBSCookieFromRequest(r, deps.OptOutCookie)
+	pc := ParsePBSCookieFromRequest(r, &deps.OptOutCookie)
 	if !pc.AllowSyncs() {
 		w.WriteHeader(http.StatusUnauthorized)
 		metrics.GetOrRegisterMeter(USERSYNC_OPT_OUT, deps.Metrics).Mark(1)
@@ -377,7 +377,7 @@ func (deps *UserSyncDeps) OptOut(w http.ResponseWriter, r *http.Request, _ httpr
 		return
 	}
 
-	pc := ParsePBSCookieFromRequest(r, deps.OptOutCookie)
+	pc := ParsePBSCookieFromRequest(r, &deps.OptOutCookie)
 	pc.SetPreference(optout == "")
 
 	pc.SetCookieOnResponse(w, deps.HostCookieSettings.Domain)

--- a/pbs/usersync_test.go
+++ b/pbs/usersync_test.go
@@ -124,7 +124,7 @@ func TestParseNilSyncMap(t *testing.T) {
 	cookieJSON := "{\"bday\":123,\"optout\":true}"
 	cookieData := base64.URLEncoding.EncodeToString([]byte(cookieJSON))
 	raw := http.Cookie{
-		Name:  COOKIE_NAME,
+		Name:  UID_COOKIE_NAME,
 		Value: cookieData,
 	}
 	parsed := ParsePBSCookie(&raw)
@@ -289,7 +289,7 @@ func writeThenRead(cookie *PBSCookie) *PBSCookie {
 	header := http.Header{}
 	header.Add("Cookie", writtenCookie)
 	request := http.Request{Header: header}
-	return ParsePBSCookieFromRequest(&request)
+	return ParsePBSCookieFromRequest(&request, "trp_optout")
 }
 
 func newTempId(uid string) uidWithExpiry {

--- a/pbs/usersync_test.go
+++ b/pbs/usersync_test.go
@@ -3,6 +3,7 @@ package pbs
 import (
 	"encoding/base64"
 	"encoding/json"
+	"github.com/prebid/prebid-server/config"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -289,7 +290,7 @@ func writeThenRead(cookie *PBSCookie) *PBSCookie {
 	header := http.Header{}
 	header.Add("Cookie", writtenCookie)
 	request := http.Request{Header: header}
-	return ParsePBSCookieFromRequest(&request, "trp_optout")
+	return ParsePBSCookieFromRequest(&request, config.Cookie{"", ""})
 }
 
 func newTempId(uid string) uidWithExpiry {

--- a/pbs/usersync_test.go
+++ b/pbs/usersync_test.go
@@ -290,7 +290,7 @@ func writeThenRead(cookie *PBSCookie) *PBSCookie {
 	header := http.Header{}
 	header.Add("Cookie", writtenCookie)
 	request := http.Request{Header: header}
-	return ParsePBSCookieFromRequest(&request, config.Cookie{})
+	return ParsePBSCookieFromRequest(&request, &config.Cookie{})
 }
 
 func newTempId(uid string) uidWithExpiry {

--- a/pbs/usersync_test.go
+++ b/pbs/usersync_test.go
@@ -290,7 +290,7 @@ func writeThenRead(cookie *PBSCookie) *PBSCookie {
 	header := http.Header{}
 	header.Add("Cookie", writtenCookie)
 	request := http.Request{Header: header}
-	return ParsePBSCookieFromRequest(&request, config.Cookie{"", ""})
+	return ParsePBSCookieFromRequest(&request, config.Cookie{})
 }
 
 func newTempId(uid string) uidWithExpiry {

--- a/pbs_light_test.go
+++ b/pbs_light_test.go
@@ -26,7 +26,7 @@ func TestCookieSyncNoCookies(t *testing.T) {
 	setupExchanges(cfg)
 	router := httprouter.New()
 
-	router.POST("/cookie_sync", (&ConfigDeps{cfg}).cookieSync)
+	router.POST("/cookie_sync", (&CookieSyncDeps{cfg.OptOutCookie}).cookieSync)
 
 	csreq := cookieSyncRequest{
 		UUID:    "abcdefg",
@@ -71,7 +71,7 @@ func TestCookieSyncHasCookies(t *testing.T) {
 	}
 	setupExchanges(cfg)
 	router := httprouter.New()
-	router.POST("/cookie_sync", (&ConfigDeps{cfg}).cookieSync)
+	router.POST("/cookie_sync", (&CookieSyncDeps{cfg.OptOutCookie}).cookieSync)
 
 	csreq := cookieSyncRequest{
 		UUID:    "abcdefg",
@@ -85,7 +85,7 @@ func TestCookieSyncHasCookies(t *testing.T) {
 
 	req, _ := http.NewRequest("POST", "/cookie_sync", csbuf)
 
-	pcs := pbs.ParsePBSCookieFromRequest(req, cfg.OptOutCookieName)
+	pcs := pbs.ParsePBSCookieFromRequest(req, cfg.OptOutCookie)
 	pcs.TrySync("adnxs", "1234")
 	pcs.TrySync("audienceNetwork", "2345")
 	req.AddCookie(pcs.ToHTTPCookie())
@@ -163,7 +163,7 @@ func TestSortBidsAndAddKeywordsForMobile(t *testing.T) {
 	d, _ := dummycache.New()
 	hcs := pbs.HostCookieSettings{}
 
-	pbs_req, err := pbs.ParsePBSRequest(r, d, &hcs, "trp_optout")
+	pbs_req, err := pbs.ParsePBSRequest(r, d, &hcs, config.Cookie{"", ""})
 	if err != nil {
 		t.Errorf("Unexpected error on parsing %v", err)
 	}

--- a/pbs_light_test.go
+++ b/pbs_light_test.go
@@ -25,7 +25,8 @@ func TestCookieSyncNoCookies(t *testing.T) {
 	}
 	setupExchanges(cfg)
 	router := httprouter.New()
-	router.POST("/cookie_sync", cookieSync)
+
+	router.POST("/cookie_sync", (&ConfigDeps{cfg}).cookieSync)
 
 	csreq := cookieSyncRequest{
 		UUID:    "abcdefg",
@@ -70,7 +71,7 @@ func TestCookieSyncHasCookies(t *testing.T) {
 	}
 	setupExchanges(cfg)
 	router := httprouter.New()
-	router.POST("/cookie_sync", cookieSync)
+	router.POST("/cookie_sync", (&ConfigDeps{cfg}).cookieSync)
 
 	csreq := cookieSyncRequest{
 		UUID:    "abcdefg",
@@ -84,7 +85,7 @@ func TestCookieSyncHasCookies(t *testing.T) {
 
 	req, _ := http.NewRequest("POST", "/cookie_sync", csbuf)
 
-	pcs := pbs.ParsePBSCookieFromRequest(req)
+	pcs := pbs.ParsePBSCookieFromRequest(req, cfg.OptOutCookieName)
 	pcs.TrySync("adnxs", "1234")
 	pcs.TrySync("audienceNetwork", "2345")
 	req.AddCookie(pcs.ToHTTPCookie())
@@ -162,7 +163,7 @@ func TestSortBidsAndAddKeywordsForMobile(t *testing.T) {
 	d, _ := dummycache.New()
 	hcs := pbs.HostCookieSettings{}
 
-	pbs_req, err := pbs.ParsePBSRequest(r, d, &hcs)
+	pbs_req, err := pbs.ParsePBSRequest(r, d, &hcs, "trp_optout")
 	if err != nil {
 		t.Errorf("Unexpected error on parsing %v", err)
 	}

--- a/pbs_light_test.go
+++ b/pbs_light_test.go
@@ -26,7 +26,7 @@ func TestCookieSyncNoCookies(t *testing.T) {
 	setupExchanges(cfg)
 	router := httprouter.New()
 
-	router.POST("/cookie_sync", (&CookieSyncDeps{cfg.OptOutCookie}).cookieSync)
+	router.POST("/cookie_sync", (CookieSyncDeps(cfg.OptOutCookie)).cookieSync)
 
 	csreq := cookieSyncRequest{
 		UUID:    "abcdefg",
@@ -71,7 +71,7 @@ func TestCookieSyncHasCookies(t *testing.T) {
 	}
 	setupExchanges(cfg)
 	router := httprouter.New()
-	router.POST("/cookie_sync", (&CookieSyncDeps{cfg.OptOutCookie}).cookieSync)
+	router.POST("/cookie_sync", (CookieSyncDeps(cfg.OptOutCookie)).cookieSync)
 
 	csreq := cookieSyncRequest{
 		UUID:    "abcdefg",
@@ -163,7 +163,7 @@ func TestSortBidsAndAddKeywordsForMobile(t *testing.T) {
 	d, _ := dummycache.New()
 	hcs := pbs.HostCookieSettings{}
 
-	pbs_req, err := pbs.ParsePBSRequest(r, d, &hcs, config.Cookie{"", ""})
+	pbs_req, err := pbs.ParsePBSRequest(r, d, &hcs, config.Cookie{})
 	if err != nil {
 		t.Errorf("Unexpected error on parsing %v", err)
 	}

--- a/pbs_light_test.go
+++ b/pbs_light_test.go
@@ -26,7 +26,7 @@ func TestCookieSyncNoCookies(t *testing.T) {
 	setupExchanges(cfg)
 	router := httprouter.New()
 
-	router.POST("/cookie_sync", (CookieSyncDeps(cfg.OptOutCookie)).cookieSync)
+	router.POST("/cookie_sync", (&CookieSyncDeps{&cfg.OptOutCookie}).cookieSync)
 
 	csreq := cookieSyncRequest{
 		UUID:    "abcdefg",
@@ -71,7 +71,7 @@ func TestCookieSyncHasCookies(t *testing.T) {
 	}
 	setupExchanges(cfg)
 	router := httprouter.New()
-	router.POST("/cookie_sync", (CookieSyncDeps(cfg.OptOutCookie)).cookieSync)
+	router.POST("/cookie_sync", (&CookieSyncDeps{&cfg.OptOutCookie}).cookieSync)
 
 	csreq := cookieSyncRequest{
 		UUID:    "abcdefg",
@@ -85,7 +85,7 @@ func TestCookieSyncHasCookies(t *testing.T) {
 
 	req, _ := http.NewRequest("POST", "/cookie_sync", csbuf)
 
-	pcs := pbs.ParsePBSCookieFromRequest(req, cfg.OptOutCookie)
+	pcs := pbs.ParsePBSCookieFromRequest(req, &cfg.OptOutCookie)
 	pcs.TrySync("adnxs", "1234")
 	pcs.TrySync("audienceNetwork", "2345")
 	req.AddCookie(pcs.ToHTTPCookie())
@@ -163,7 +163,7 @@ func TestSortBidsAndAddKeywordsForMobile(t *testing.T) {
 	d, _ := dummycache.New()
 	hcs := pbs.HostCookieSettings{}
 
-	pbs_req, err := pbs.ParsePBSRequest(r, d, &hcs, config.Cookie{})
+	pbs_req, err := pbs.ParsePBSRequest(r, d, &hcs, &config.Cookie{})
 	if err != nil {
 		t.Errorf("Unexpected error on parsing %v", err)
 	}


### PR DESCRIPTION
pbs.json takes 
"optout_cookie": {
      "name": "trp_optout",
      "value": "true"
    }
When defined in pbs.json, the opt out cookie, if found, is checked for that value.
If equal to that value, then uids cookie is not parsed and AllowSyncs() returns false.